### PR TITLE
Add chronicle activation height

### DIFF
--- a/params.go
+++ b/params.go
@@ -151,9 +151,10 @@ type Params struct {
 
 	// The following are the heights at which the Bitcoin-specific forks
 	// became active.
-	UahfForkHeight          uint32 // August 1, 2017, hard fork
-	DaaForkHeight           uint32 // November 13, 2017 hard fork
-	GenesisActivationHeight uint32 // Genesis activation height
+	UahfForkHeight            uint32 // August 1, 2017, hard fork
+	DaaForkHeight             uint32 // November 13, 2017 hard fork
+	GenesisActivationHeight   uint32 // Genesis activation height
+	ChronicleActivationHeight uint32 // Chronicle activation height
 
 	// CoinbaseMaturity is the number of blocks required before newly mined
 	// coins (coinbase transactions) can be spent.
@@ -266,16 +267,17 @@ var MainNetParams = Params{
 	// November 13, 2017, hard fork
 	DaaForkHeight: 504031, // 0000000000000000011ebf65b60d0a3de80b8175be709d653b4c1a1beeb6ab9c
 
-	GenesisActivationHeight:  620538,
-	MaxCoinbaseScriptSigSize: 100,
-	CoinbaseMaturity:         100,
-	SubsidyReductionInterval: 210000,
-	TargetTimePerBlock:       time.Minute * 10, // 10 minutes
-	RetargetAdjustmentFactor: 4,                // 25% less, 400% more
-	ReduceMinDifficulty:      false,
-	NoDifficultyAdjustment:   false,
-	MinDiffReductionTime:     0,
-	GenerateSupported:        false,
+	GenesisActivationHeight:   620538,
+	ChronicleActivationHeight: 921788, // temporary and subject to change
+	MaxCoinbaseScriptSigSize:  100,
+	CoinbaseMaturity:          100,
+	SubsidyReductionInterval:  210000,
+	TargetTimePerBlock:        time.Minute * 10, // 10 minutes
+	RetargetAdjustmentFactor:  4,                // 25% less, 400% more
+	ReduceMinDifficulty:       false,
+	NoDifficultyAdjustment:    false,
+	MinDiffReductionTime:      0,
+	GenerateSupported:         false,
 
 	// Checkpoints ordered from oldest to newest.
 	Checkpoints: []Checkpoint{
@@ -378,7 +380,8 @@ var StnParams = Params{
 	// November 13, 2017, hard fork
 	DaaForkHeight: 2200, // must be > 2016
 
-	GenesisActivationHeight: 100,
+	GenesisActivationHeight:   100,
+	ChronicleActivationHeight: 250, // temporary and subject to change
 
 	SubsidyReductionInterval: 210000,
 	TargetTimePerBlock:       time.Minute * 10, // 10 minutes
@@ -458,7 +461,8 @@ var RegressionNetParams = Params{
 	// November 13, 2017, hard fork is always on regtest.
 	DaaForkHeight: 0,
 
-	GenesisActivationHeight: 10000,
+	GenesisActivationHeight:   10000,
+	ChronicleActivationHeight: 15000, // temporary and subject to change
 
 	SubsidyReductionInterval: 150,
 	TargetTimePerBlock:       time.Minute * 10, // 10 minutes
@@ -538,9 +542,10 @@ var TestNetParams = Params{
 	// November 13, 2017, hard fork
 	DaaForkHeight: 1188697, // 0000000000170ed0918077bde7b4d36cc4c91be69fa09211f748240dabe047fb
 
-	GenesisActivationHeight:  1344302,
-	MaxCoinbaseScriptSigSize: 100,
-	CoinbaseMaturity:         100,
+	GenesisActivationHeight:   1344302,
+	ChronicleActivationHeight: 1686611, // temporary and subject to change
+	MaxCoinbaseScriptSigSize:  100,
+	CoinbaseMaturity:          100,
 
 	SubsidyReductionInterval: 210000,
 	TargetTimePerBlock:       time.Minute * 10, // 10 minutes
@@ -630,10 +635,11 @@ var TeraTestNetParams = Params{
 
 	UahfForkHeight: 0, // always enabled
 
-	DaaForkHeight:            0, // always enabled
-	GenesisActivationHeight:  1,
-	MaxCoinbaseScriptSigSize: 100,
-	CoinbaseMaturity:         10, // coinbase matures after 10 confirmations
+	DaaForkHeight:             0, // always enabled
+	GenesisActivationHeight:   1,
+	ChronicleActivationHeight: 2, // temporary and subject to change
+	MaxCoinbaseScriptSigSize:  100,
+	CoinbaseMaturity:          10, // coinbase matures after 10 confirmations
 
 	SubsidyReductionInterval: 210000,
 	TargetTimePerBlock:       time.Minute * 10, // 10 minutes
@@ -702,10 +708,11 @@ var TeraScalingTestNetParams = Params{
 
 	UahfForkHeight: 0, // always enabled
 
-	DaaForkHeight:            0, // always enabled
-	GenesisActivationHeight:  1,
-	MaxCoinbaseScriptSigSize: 100,
-	CoinbaseMaturity:         10, // coinbase matures after 10 confirmations
+	DaaForkHeight:             0, // always enabled
+	GenesisActivationHeight:   1,
+	ChronicleActivationHeight: 2, // temporary and subject to change
+	MaxCoinbaseScriptSigSize:  100,
+	CoinbaseMaturity:          10, // coinbase matures after 10 confirmations
 
 	SubsidyReductionInterval: 210000,
 	TargetTimePerBlock:       time.Minute * 10, // 10 minutes


### PR DESCRIPTION
This pull request introduces a new parameter, `ChronicleActivationHeight`, to the `Params` struct in `params.go` and updates its value for various network configurations. These changes are intended to prepare for the activation of a new feature or protocol upgrade across multiple networks.

### Addition of `ChronicleActivationHeight`:

* **Struct Update**:
  - Added `ChronicleActivationHeight` to the `Params` struct to define the activation height for the Chronicle feature.

* **Network-Specific Values**:
  - **MainNet**: Set `ChronicleActivationHeight` to `921788` (temporary and subject to change).
  - **Stn**: Set `ChronicleActivationHeight` to `250` (temporary and subject to change).
  - **RegressionNet**: Set `ChronicleActivationHeight` to `15000` (temporary and subject to change).
  - **TestNet**: Set `ChronicleActivationHeight` to `1686611` (temporary and subject to change).
  - **TeraTestNet**: Set `ChronicleActivationHeight` to `2` (temporary and subject to change).
  - **TeraScalingTestNet**: Set `ChronicleActivationHeight` to `2` (temporary and subject to change).