### PR TITLE
[Docs] Remove obsolete command from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,6 @@ govulncheck-install   ## Install govulncheck
 help                  ## Display this help message
 install-go            ## Install using go install with specific version
 install-releaser      ## Install GoReleaser
-install-template      ## Kick-start a fresh copy of go-chaincfg (run once!)
 install               ## Install the application binary
 lint                  ## Run the golangci-lint application (install if not found)
 release-snap          ## Build snapshot binaries


### PR DESCRIPTION
## What Changed
- removed `install-template` entry from the Makefile command list in README

## Why It Was Necessary
- the `install-template` command is no longer present or recommended, so the documentation should not reference it

## Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`

## Impact / Risk
- minimal; documentation update only

------
https://chatgpt.com/codex/tasks/task_e_6866b6c498208321a3a5de7e673f1805