### PR TITLE
Update params.go for lower activation heights for genesis and chronicle

### DIFF
--- a/params.go
+++ b/params.go
@@ -472,8 +472,8 @@ var RegressionNetParams = Params{
 	// November 13, 2017, hard fork is always on regtest.
 	DaaForkHeight: 0,
 
-	GenesisActivationHeight:   10000,
-	ChronicleActivationHeight: 15000, // temporary and subject to change
+	GenesisActivationHeight:   100,
+	ChronicleActivationHeight: 200, // temporary and subject to change
 
 	SubsidyReductionInterval: 150,
 	TargetTimePerBlock:       time.Minute * 10, // 10 minutes


### PR DESCRIPTION
This pull request updates the activation heights for two network upgrades on the regression test network in the `params.go` file. These changes lower the block heights at which the Genesis and Chronicle upgrades activate, making it easier and faster to test these features in a regtest environment.

Network upgrade activation heights:

* Lowered `GenesisActivationHeight` from 10,000 to 100 in the `RegressionNetParams` to speed up regtest activation.
* Lowered `ChronicleActivationHeight` from 15,000 to 200 in the `RegressionNetParams` for more accessible regtest testing.